### PR TITLE
feat(route-recognizer): return the registered state from add

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -347,6 +347,8 @@ export class RouteRecognizer {
     currentState.handlers = handlers;
     currentState.regex = new RegExp(regex + '$');
     currentState.types = types;
+
+    return currentState;
   }
 
   handlersFor(name) {


### PR DESCRIPTION
This allows consumers to inspect parsed route data, such as segment types.