### PR TITLE
feat(route-recognizer): don't encode '$' in query string keys

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -169,7 +169,8 @@ export class RouteRecognizer {
    * @return {String} The generated query string, including leading '?'.
    */
   generateQueryString(params) {
-    var pairs = [], keys = [], encode = encodeURIComponent;
+    var pairs = [], keys = [], encode = encodeURIComponent,
+      encodeKey = k => encode(k).replace('%24', '$');
 
     for (var key in params) {
       if (params.hasOwnProperty(key)) {
@@ -186,12 +187,12 @@ export class RouteRecognizer {
       }
 
       if (Array.isArray(value)) {
-        var arrayKey = `${encode(key)}[]`;
+        var arrayKey = `${encodeKey(key)}[]`;
         for (var j = 0, l = value.length; j < l; j++) {
           pairs.push(`${arrayKey}=${encode(value[j])}`);
         }
       } else {
-        pairs.push(`${encode(key)}=${encode(value)}`);
+        pairs.push(`${encodeKey(key)}=${encode(value)}`);
       }
     }
 

--- a/test/route-recognizer.spec.js
+++ b/test/route-recognizer.spec.js
@@ -138,6 +138,7 @@ describe('route recognizer', () => {
     expect(gen({ a: '&' })).toBe('?a=%26');
     expect(gen({ '&': 'a' })).toBe('?%26=a');
     expect(gen({ a: true })).toBe('?a=true');
+    expect(gen({ '$test': true })).toBe('?$test=true');
   });
 
   it('should parse query strings', () => {


### PR DESCRIPTION
$ is commonly used in ODATA queries. encodeURIComponent percent-encodes it, but it's not required to be encoded.

Fixes aurelia/router#108