### PR TITLE
fix(route-recognizer): Use correct import for core-js

### DIFF
--- a/src/route-recognizer.js
+++ b/src/route-recognizer.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 import {State} from './state';
 import {
   StaticSegment,


### PR DESCRIPTION
We were previously using `import core from core-js` which generates d.ts that do not match the corejs d.ts. This is now updated to `import * as core 'core-js'`, which resolves TypeScript compilation warnings.

closes aurelia/framework#177