### PR TITLE
Support multiple names for a single route

### DIFF
--- a/src/route-recognizer.js
+++ b/src/route-recognizer.js
@@ -64,10 +64,13 @@ export class RouteRecognizer {
     let handlers = [{ handler: route.handler, names: names }];
 
     if (routeName) {
-      this.names[routeName] = {
-        segments: segments,
-        handlers: handlers
-      };
+      let routeNames = Array.isArray(routeName) ? routeName : [routeName];
+      for (let i = 0; i < routeNames.length; i++) {
+        this.names[routeNames[i]] = {
+          segments: segments,
+          handlers: handlers
+        };
+      }
     }
 
     currentState.handlers = handlers;

--- a/test/route-recognizer.spec.js
+++ b/test/route-recognizer.spec.js
@@ -3,6 +3,7 @@ import core from 'core-js';
 
 const staticRoute = {'path': 'static','handler': {'name': 'static'}};
 const dynamicRoute = {'path': 'dynamic/:id','handler': {'name': 'dynamic'}};
+const multiNameRoute = {'path': 'static','handler': {'name': ['static-multiple', 'static-multiple-alias']}};
 
 const routeTestData = [{
     title: 'empty path routes',
@@ -116,5 +117,13 @@ describe('route recognizer', () => {
 
     expect(recognizer.hasRoute('static')).toBe(true);
     expect(recognizer.handlersFor('static')[0].handler).toEqual(staticRoute.handler);
+  });
+
+  it('should find a handler by multiple names', () => {
+    let recognizer = new RouteRecognizer();
+    recognizer.add([multiNameRoute]);
+
+    expect(recognizer.handlersFor('static-multiple')[0].handler)
+      .toEqual(recognizer.handlersFor('static-multiple-alias')[0].handler)
   });
 });


### PR DESCRIPTION
Simple change that makes this work:

`{ route: 'somepath', name: ['somepath', 'somepath-alias'], moduleId: 'somevm' },`

I did this for myself so I can generate a canonical route url from various names available at runtime.