### PR TITLE
fix(route-recognizer): route recognizer is case insensitive by default

### DIFF
--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -5,6 +5,7 @@ interface RouteHandler {
 interface ConfigurableRoute {
   path: string;
   handler: RouteHandler;
+  caseSensitive: boolean;
 }
 
 interface HandlerEntry {

--- a/src/route-recognizer.js
+++ b/src/route-recognizer.js
@@ -36,7 +36,7 @@ export class RouteRecognizer {
     let names = [];
     let routeName = route.handler.name;
     let isEmpty = true;
-    let segments = parse(route.path, names, types);
+    let segments = parse(route.path, names, types, route.caseSensitive);
 
     for (let i = 0, ii = segments.length; i < ii; i++) {
       let segment = segments[i];
@@ -73,7 +73,7 @@ export class RouteRecognizer {
     }
 
     currentState.handlers = handlers;
-    currentState.regex = new RegExp(regex + '$');
+    currentState.regex = new RegExp(regex + '$', route.caseSensitive ? '' : 'i');
     currentState.types = types;
 
     return currentState;
@@ -227,7 +227,7 @@ class RecognizeResults {
   }
 }
 
-function parse(route, names, types) {
+function parse(route, names, types, caseSensitive) {
   // normalize route as not starting with a '/'. Recognition will
   // also normalize.
   let normalizedRoute = route;
@@ -256,7 +256,7 @@ function parse(route, names, types) {
     } else if (segment === '') {
       results.push(new EpsilonSegment());
     } else {
-      results.push(new StaticSegment(segment));
+      results.push(new StaticSegment(segment, caseSensitive));
       types.statics++;
     }
   }

--- a/src/segments.js
+++ b/src/segments.js
@@ -23,15 +23,16 @@ const escapeRegex = new RegExp('(\\' + specials.join('|\\') + ')', 'g');
 // * `repeat`: true if the character specification can repeat
 
 export class StaticSegment {
-  constructor(string: string) {
+  constructor(string: string, caseSensitive: boolean) {
     this.string = string;
+    this.caseSensitive = caseSensitive;
   }
 
   eachChar(callback: (spec: CharSpec) => void): void {
     let s = this.string;
     for (let i = 0, ii = s.length; i < ii; ++i) {
       let ch = s[i];
-      callback({ validChars: ch });
+      callback({ validChars: this.caseSensitive ? ch : ch.toUpperCase() + ch.toLowerCase() });
     }
   }
 

--- a/test/route-recognizer.spec.js
+++ b/test/route-recognizer.spec.js
@@ -82,6 +82,20 @@ describe('route recognizer', () => {
       expect(result[0].params).toEqual(routeTest.params);
     });
 
+    it(`its case insensitive by default ${routeTest.title}`, () => {      
+      let recognizer = new RouteRecognizer();
+      recognizer.add([routeTest.route]);
+
+      let result = recognizer.recognize(routeTest.path.toUpperCase());
+      expect(result).toBeTruthy();
+      expect(result.length).toBe(1);
+      expect(result[0].handler).toEqual(routeTest.route.handler);
+      expect(result[0].isDynamic).toBe(routeTest.isDynamic);
+      Object.keys(result[0].params).forEach((property) => {
+        expect(result[0].params[property].toUpperCase()).toEqual(routeTest.params[property].toUpperCase());
+      });
+    });
+
     it(`should generate ${routeTest.title}`, () => {
       let recognizer = new RouteRecognizer();
       recognizer.add([routeTest.route]);
@@ -127,5 +141,20 @@ describe('route recognizer', () => {
 
     expect(recognizer.handlersFor('static-multiple')[0].handler)
       .toEqual(recognizer.handlersFor('static-multiple-alias')[0].handler)
+  });  
+    
+  it(`can set case sensitive route and fails`, () => {
+    let recognizer = new RouteRecognizer();
+    const routeTest = {
+      title: 'case sensitive route',
+      route: { 'path': 'CasE/InSeNsItIvE', 'handler': { 'name': 'static' }, 'caseSensitive': true },
+      isDynamic: false,
+      path: 'CasE/iNsEnSiTiVe',
+      params: {}
+    };
+    recognizer.add([routeTest.route]);
+
+    let result = recognizer.recognize(routeTest.path);
+    expect(result).toBeUndefined();
   });
 });


### PR DESCRIPTION
Route recognizer is case insensitive by default, if you need to set some route as case sensitive you can add `caseSensitive: true` property to the route.

in order to close https://github.com/aurelia/router/issues/271