### PR TITLE
Optional parameters in routes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,4 @@ insert_final_newline = true
 [**.*]
 indent_style = space
 indent_size = 2
+trim_trailing_whitespace = true

--- a/src/route-recognizer.js
+++ b/src/route-recognizer.js
@@ -3,7 +3,6 @@ import {State} from './state';
 import {
   StaticSegment,
   DynamicSegment,
-  ConstrainedSegment,
   StarSegment,
   EpsilonSegment
 } from './segments';
@@ -256,32 +255,21 @@ function parse(route, names, types, caseSensitive) {
   for (let i = 0, ii = splitRoute.length; i < ii; ++i) {
     let segment = splitRoute[i];
 
-    // Try to parse basic syntax :param
-    let match = segment.match(/^:([^\/]+)$/);
-    if (match) {
-      results.push(new DynamicSegment(match[1]));
-      names.push(match[1]);
-      types.dynamics++;
-      continue;
-    }
-
-    // Try to parse extended syntax {param?}
-    match = segment.match(/^\{(.+?)(\?)?\}$/);
+    // Try to parse a parameter :param?
+    let match = segment.match(/^:([^?]+)(\?)?$/);
     if (match) {
       let [, name, optional] = match;
       if (name.indexOf('=') !== -1) {
         throw new Error(`Parameter ${name} in route ${route} has a default value, which is not supported.`);
       }
-      if (name.indexOf(':') !== -1) {
-        throw new Error(`Parameter ${name} in route ${route} has a constraint, which is not supported.`);
-      }
-      results.push(new ConstrainedSegment(name, !!optional));
+      results.push(new DynamicSegment(name, !!optional));
       names.push(name);
       types.dynamics++;
       continue;
     }
 
-    match = segment.match(/^\*([^\/]+)$/);
+    // Try to parse a star segment *whatever
+    match = segment.match(/^\*(.+)$/);
     if (match) {
       results.push(new StarSegment(match[1]));
       names.push(match[1]);

--- a/src/segments.js
+++ b/src/segments.js
@@ -64,6 +64,26 @@ export class DynamicSegment {
   }
 }
 
+export class ConstrainedSegment {
+  constructor(name: string, optional: boolean) {
+    this.name = name;
+    this.optional = optional;
+  }
+
+  eachChar(callback: (spec: CharSpec) => void): void {
+    callback({ invalidChars: '/', repeat: true });    
+  }
+
+  regex(): string {
+    return this.optional ? '([^/]+)?' : '([^/]+)';
+  }
+
+  generate(params: Object, consumed: Object): string {
+    consumed[this.name] = true;
+    return params[this.name];
+  }
+}
+
 export class StarSegment {
   constructor(name: string) {
     this.name = name;

--- a/src/segments.js
+++ b/src/segments.js
@@ -46,25 +46,6 @@ export class StaticSegment {
 }
 
 export class DynamicSegment {
-  constructor(name: string) {
-    this.name = name;
-  }
-
-  eachChar(callback: (spec: CharSpec) => void): void {
-    callback({ invalidChars: '/', repeat: true });
-  }
-
-  regex(): string {
-    return '([^/]+)';
-  }
-
-  generate(params: Object, consumed: Object): string {
-    consumed[this.name] = true;
-    return params[this.name];
-  }
-}
-
-export class ConstrainedSegment {
   constructor(name: string, optional: boolean) {
     this.name = name;
     this.optional = optional;

--- a/src/segments.js
+++ b/src/segments.js
@@ -71,7 +71,7 @@ export class ConstrainedSegment {
   }
 
   eachChar(callback: (spec: CharSpec) => void): void {
-    callback({ invalidChars: '/', repeat: true });    
+    callback({ invalidChars: '/', repeat: true });
   }
 
   regex(): string {

--- a/test/route-recognizer.spec.js
+++ b/test/route-recognizer.spec.js
@@ -48,44 +48,38 @@ const routeTestData = [{
     path: '/dynamic/foo/star/test/path',
     params: { id: 'foo', path: 'test/path' }
   }, {
-    title: 'constrained routes',
-    route: { 'path': 'param/{id}/edit', 'handler' : { 'name': 'constrained' }},
+    title: 'optional parameter routes',
+    route: { 'path': 'param/:id?/edit', 'handler': { 'name': 'constrained' }},
     isDynamic: true,
     path: '/param/42/edit',
     params: { id: '42' }
   }, {
-    title: 'optional constrained routes',
-    route: { 'path': 'param/{id?}/edit', 'handler': { 'name': 'constrained' }},
-    isDynamic: true,
-    path: '/param/42/edit',
-    params: { id: '42' }
-  }, {
-    title: 'missing optional constrained routes',
-    route: { 'path': 'param/{id?}/edit', 'handler': { 'name': 'constrained' }},
+    title: 'missing optional parameter routes',
+    route: { 'path': 'param/:id?/edit', 'handler': { 'name': 'constrained' }},
     isDynamic: true,
     path: '/param/edit',
     params: { id: undefined }
   }, {
-    title: 'multiple optional constrained routes',
-    route: { 'path': 'param/{x?}/edit/{y?}', 'handler': { 'name': 'constrained' }},
+    title: 'multiple optional parameters routes',
+    route: { 'path': 'param/:x?/edit/:y?', 'handler': { 'name': 'constrained' }},
     isDynamic: true,
     path: '/param/edit/42',
     params: { x: undefined, y: '42' }
   }, {
-    title: 'ambiguous constrained routes',
-    route: { 'path': 'pt/{x?}/{y?}', 'handler': { 'name': 'constrained' }},
+    title: 'ambiguous optional parameters routes',
+    route: { 'path': 'pt/:x?/:y?', 'handler': { 'name': 'constrained' }},
     isDynamic: true,
     path: '/pt/7',
     params: { x: '7', y: undefined }
   }, {
-    title: 'empty constrained routes',
-    route: { 'path': '{x?}/{y?}', 'handler': { 'name': 'constrained' }},
+    title: 'empty optional parameters routes',
+    route: { 'path': ':x?/:y?', 'handler': { 'name': 'constrained' }},
     isDynamic: true,
     path: '/',
     params: { x: undefined, y: undefined }
   }, {
-    title: 'almost empty constrained routes',
-    route: { 'path': '{x?}', 'handler': { 'name': 'constrained' }},
+    title: 'almost empty optional parameter routes',
+    route: { 'path': ':x?', 'handler': { 'name': 'constrained' }},
     isDynamic: true,
     path: '/42',
     params: { x: '42' }
@@ -104,13 +98,7 @@ describe('route recognizer', () => {
   it('should reject default parameter values', () => {
     let recognizer = new RouteRecognizer();
 
-    expect(() => recognizer.add([{'path': 'user/{id=1}', 'handler': {}}])).toThrow();
-  });
-
-  it('should reject parameter constraints', () => {
-    let recognizer = new RouteRecognizer();
-
-    expect(() => recognizer.add([{'path': 'user/{id:int}', 'handler': {}}])).toThrow();
+    expect(() => recognizer.add([{'path': 'user/:id=1', 'handler': {}}])).toThrow();
   });
 
   it('should register unnamed routes', () => {
@@ -136,7 +124,7 @@ describe('route recognizer', () => {
       expect(result[0].params).toEqual(routeTest.params);
     });
 
-    it(`its case insensitive by default ${routeTest.title}`, () => {      
+    it(`its case insensitive by default ${routeTest.title}`, () => {
       let recognizer = new RouteRecognizer();
       recognizer.add([routeTest.route]);
 
@@ -198,8 +186,8 @@ describe('route recognizer', () => {
 
     expect(recognizer.handlersFor('static-multiple')[0].handler)
       .toEqual(recognizer.handlersFor('static-multiple-alias')[0].handler)
-  });  
-    
+  });
+
   it(`can set case sensitive route and fails`, () => {
     let recognizer = new RouteRecognizer();
     const routeTest = {

--- a/test/route-recognizer.spec.js
+++ b/test/route-recognizer.spec.js
@@ -47,6 +47,48 @@ const routeTestData = [{
     isDynamic: true,
     path: '/dynamic/foo/star/test/path',
     params: { id: 'foo', path: 'test/path' }
+  }, {
+    title: 'constrained routes',
+    route: { 'path': 'param/{id}/edit', 'handler' : { 'name': 'constrained' }},
+    isDynamic: true,
+    path: '/param/42/edit',
+    params: { id: '42' }
+  }, {
+    title: 'optional constrained routes',
+    route: { 'path': 'param/{id?}/edit', 'handler': { 'name': 'constrained' }},
+    isDynamic: true,
+    path: '/param/42/edit',
+    params: { id: '42' }
+  }, {
+    title: 'missing optional constrained routes',
+    route: { 'path': 'param/{id?}/edit', 'handler': { 'name': 'constrained' }},
+    isDynamic: true,
+    path: '/param/edit',
+    params: { id: undefined }
+  }, {
+    title: 'multiple optional constrained routes',
+    route: { 'path': 'param/{x?}/edit/{y?}', 'handler': { 'name': 'constrained' }},
+    isDynamic: true,
+    path: '/param/edit/42',
+    params: { x: undefined, y: '42' }
+  }, {
+    title: 'ambiguous constrained routes',
+    route: { 'path': 'pt/{x?}/{y?}', 'handler': { 'name': 'constrained' }},
+    isDynamic: true,
+    path: '/pt/7',
+    params: { x: '7', y: undefined }
+  }, {
+    title: 'empty constrained routes',
+    route: { 'path': '{x?}/{y?}', 'handler': { 'name': 'constrained' }},
+    isDynamic: true,
+    path: '/',
+    params: { x: undefined, y: undefined }
+  }, {
+    title: 'almost empty constrained routes',
+    route: { 'path': '{x?}', 'handler': { 'name': 'constrained' }},
+    isDynamic: true,
+    path: '/42',
+    params: { x: '42' }
   }];
 
 describe('route recognizer', () => {
@@ -57,6 +99,18 @@ describe('route recognizer', () => {
     expect(() => recognizer.handlersFor('static')).toThrow();
     expect(() => recognizer.generate('static')).toThrow();
     expect(recognizer.recognize('/notfound')).toBeUndefined();
+  });
+
+  it('should reject default parameter values', () => {
+    let recognizer = new RouteRecognizer();
+
+    expect(() => recognizer.add([{'path': 'user/{id=1}', 'handler': {}}])).toThrow();
+  });
+
+  it('should reject parameter constraints', () => {
+    let recognizer = new RouteRecognizer();
+
+    expect(() => recognizer.add([{'path': 'user/{id:int}', 'handler': {}}])).toThrow();
   });
 
   it('should register unnamed routes', () => {
@@ -92,6 +146,9 @@ describe('route recognizer', () => {
       expect(result[0].handler).toEqual(routeTest.route.handler);
       expect(result[0].isDynamic).toBe(routeTest.isDynamic);
       Object.keys(result[0].params).forEach((property) => {
+        if (routeTest.params[property] === undefined) {
+          return;
+        }
         expect(result[0].params[property].toUpperCase()).toEqual(routeTest.params[property].toUpperCase());
       });
     });

--- a/test/route-recognizer.spec.js
+++ b/test/route-recognizer.spec.js
@@ -49,37 +49,37 @@ const routeTestData = [{
     params: { id: 'foo', path: 'test/path' }
   }, {
     title: 'optional parameter routes',
-    route: { 'path': 'param/:id?/edit', 'handler': { 'name': 'constrained' }},
+    route: { 'path': 'param/:id?/edit', 'handler': { 'name': 'dynamic' }},
     isDynamic: true,
     path: '/param/42/edit',
     params: { id: '42' }
   }, {
     title: 'missing optional parameter routes',
-    route: { 'path': 'param/:id?/edit', 'handler': { 'name': 'constrained' }},
+    route: { 'path': 'param/:id?/edit', 'handler': { 'name': 'dynamic' }},
     isDynamic: true,
     path: '/param/edit',
     params: { id: undefined }
   }, {
     title: 'multiple optional parameters routes',
-    route: { 'path': 'param/:x?/edit/:y?', 'handler': { 'name': 'constrained' }},
+    route: { 'path': 'param/:x?/edit/:y?', 'handler': { 'name': 'dynamic' }},
     isDynamic: true,
     path: '/param/edit/42',
     params: { x: undefined, y: '42' }
   }, {
     title: 'ambiguous optional parameters routes',
-    route: { 'path': 'pt/:x?/:y?', 'handler': { 'name': 'constrained' }},
+    route: { 'path': 'pt/:x?/:y?', 'handler': { 'name': 'dynamic' }},
     isDynamic: true,
     path: '/pt/7',
     params: { x: '7', y: undefined }
   }, {
     title: 'empty optional parameters routes',
-    route: { 'path': ':x?/:y?', 'handler': { 'name': 'constrained' }},
+    route: { 'path': ':x?/:y?', 'handler': { 'name': 'dynamic' }},
     isDynamic: true,
     path: '/',
     params: { x: undefined, y: undefined }
   }, {
     title: 'almost empty optional parameter routes',
-    route: { 'path': ':x?', 'handler': { 'name': 'constrained' }},
+    route: { 'path': ':x?', 'handler': { 'name': 'dynamic' }},
     isDynamic: true,
     path: '/42',
     params: { x: '42' }


### PR DESCRIPTION
Related to aurelia/router#83.

This PR introduces two things.

First it adds support for the ASP.NET route parameter format: `/user/{id}`. 

Idea is that the existing basic format `:id` continues to work and is supported but without fancy options.

The alternative `{id}` format supports additional options, with a syntax familiar to ASP.NET devs.

This PR already adds support for optional parameters, like `{id?}`.

It also checks for default values `{id=42}` and constraints `{id:int}` and throws a "not supported" error so that those can safely be added in the future.

I also added tests, including 7 new valid routes that uses the new syntax and 2 test cases for the unsupported defaults and constraints.