### PR TITLE
feat(route-recognizer): Support generating a route by config as well as name

### DIFF
--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -1,3 +1,5 @@
+import { StaticSegment, DynamicSegment, StarSegment, EpsilonSegment } from './segments';
+
 interface RouteHandler {
   name: string;
 }
@@ -23,4 +25,13 @@ interface CharSpec {
   invalidChars?: string;
   validChars?: string;
   repeat?: boolean;
+}
+
+type Segment = StaticSegment | DynamicSegment | StarSegment | EpsilonSegment;
+/**
+ * An object that is indexed and used for route generation, particularly for dynamic routes.
+ */
+interface RouteGenerator {
+  segments: Segment[];
+  handlers: HandlerEntry[];
 }

--- a/src/route-recognizer.js
+++ b/src/route-recognizer.js
@@ -106,14 +106,20 @@ export class RouteRecognizer {
     return currentState;
   }
 
+  /**
+  * Retrieve a RouteGenerator for a route by name or RouteConfig (RouteHandler).
+  *
+  * @param nameOrRoute The name of the route or RouteConfig object.
+  * @returns The RouteGenerator for that route.
+  */
   getRoute(nameOrRoute: string | RouteHandler): RouteGenerator {
     return typeof(nameOrRoute) === 'string' ? this.names[nameOrRoute] : this.routes.get(nameOrRoute);
   }
 
   /**
-  * Retrieve the handlers registered for the named route.
+  * Retrieve the handlers registered for the route by name or RouteConfig (RouteHandler).
   *
-  * @param name The name of the route.
+  * @param nameOrRoute The name of the route or RouteConfig object.
   * @returns The handlers.
   */
   handlersFor(nameOrRoute: string | RouteHandler): HandlerEntry[] {
@@ -126,9 +132,9 @@ export class RouteRecognizer {
   }
 
   /**
-  * Check if this RouteRecognizer recognizes a named route.
+  * Check if this RouteRecognizer recognizes a route by name or RouteConfig (RouteHandler).
   *
-  * @param name The name of the route.
+  * @param nameOrRoute The name of the route or RouteConfig object.
   * @returns True if the named route is recognized.
   */
   hasRoute(nameOrRoute: string | RouteHandler): boolean {
@@ -136,9 +142,9 @@ export class RouteRecognizer {
   }
 
   /**
-  * Generate a path and query string from a route name and params object.
+  * Generate a path and query string from a route name or RouteConfig (RouteHandler) and params object.
   *
-  * @param name The name of the route.
+  * @param nameOrRoute The name of the route or RouteConfig object.
   * @param params The route params to use when populating the pattern.
   *  Properties not required by the pattern will be appended to the query string.
   * @returns The generated absolute path and query string.

--- a/src/route-recognizer.js
+++ b/src/route-recognizer.js
@@ -106,7 +106,7 @@ export class RouteRecognizer {
     return currentState;
   }
 
-  getRoute(nameOrRoute: string | RouteHandler): any {
+  getRoute(nameOrRoute: string | RouteHandler): RouteGenerator {
     return typeof(nameOrRoute) === 'string' ? this.names[nameOrRoute] : this.routes.get(nameOrRoute);
   }
 
@@ -131,7 +131,7 @@ export class RouteRecognizer {
   * @param name The name of the route.
   * @returns True if the named route is recognized.
   */
-  hasRoute(nameOrRoute: string | ConfigurableRoute): boolean {
+  hasRoute(nameOrRoute: string | RouteHandler): boolean {
     return !!this.getRoute(nameOrRoute);
   }
 
@@ -143,7 +143,7 @@ export class RouteRecognizer {
   *  Properties not required by the pattern will be appended to the query string.
   * @returns The generated absolute path and query string.
   */
-  generate(nameOrRoute: string, params: Object): string {
+  generate(nameOrRoute: string | RouteHandler, params: object): string {
     let route = this.getRoute(nameOrRoute);
     if (!route) {
       throw new Error(`There is no route named ${nameOrRoute}`);

--- a/src/route-recognizer.js
+++ b/src/route-recognizer.js
@@ -17,6 +17,7 @@ export class RouteRecognizer {
   constructor() {
     this.rootState = new State();
     this.names = {};
+    this.routes = new Map();
   }
 
   /**
@@ -79,13 +80,13 @@ export class RouteRecognizer {
 
     let handlers = [{ handler: route.handler, names: names }];
 
+    this.routes.set(route.handler, { segments, handlers });
     if (routeName) {
       let routeNames = Array.isArray(routeName) ? routeName : [routeName];
       for (let i = 0; i < routeNames.length; i++) {
-        this.names[routeNames[i]] = {
-          segments: segments,
-          handlers: handlers
-        };
+        if (!(routeNames[i] in this.names)) {
+          this.names[routeNames[i]] = { segments, handlers };
+        }
       }
     }
 
@@ -105,16 +106,20 @@ export class RouteRecognizer {
     return currentState;
   }
 
+  getRoute(nameOrRoute: string | RouteHandler): any {
+    return typeof(nameOrRoute) === 'string' ? this.names[nameOrRoute] : this.routes.get(nameOrRoute);
+  }
+
   /**
   * Retrieve the handlers registered for the named route.
   *
   * @param name The name of the route.
   * @returns The handlers.
   */
-  handlersFor(name: string): HandlerEntry[] {
-    let route = this.names[name];
+  handlersFor(nameOrRoute: string | RouteHandler): HandlerEntry[] {
+    let route = this.getRoute(nameOrRoute);
     if (!route) {
-      throw new Error(`There is no route named ${name}`);
+      throw new Error(`There is no route named ${nameOrRoute}`);
     }
 
     return [...route.handlers];
@@ -126,8 +131,8 @@ export class RouteRecognizer {
   * @param name The name of the route.
   * @returns True if the named route is recognized.
   */
-  hasRoute(name: string): boolean {
-    return !!this.names[name];
+  hasRoute(nameOrRoute: string | ConfigurableRoute): boolean {
+    return !!this.getRoute(nameOrRoute);
   }
 
   /**
@@ -138,10 +143,10 @@ export class RouteRecognizer {
   *  Properties not required by the pattern will be appended to the query string.
   * @returns The generated absolute path and query string.
   */
-  generate(name: string, params: Object): string {
-    let route = this.names[name];
+  generate(nameOrRoute: string, params: Object): string {
+    let route = this.getRoute(nameOrRoute);
     if (!route) {
-      throw new Error(`There is no route named ${name}`);
+      throw new Error(`There is no route named ${nameOrRoute}`);
     }
 
     let handler = route.handlers[0].handler;
@@ -164,7 +169,7 @@ export class RouteRecognizer {
       let segmentValue = segment.generate(routeParams, consumed);
       if (segmentValue === null || segmentValue === undefined) {
         if (!segment.optional) {
-          throw new Error(`A value is required for route parameter '${segment.name}' in route '${name}'.`);
+          throw new Error(`A value is required for route parameter '${segment.name}' in route '${nameOrRoute}'.`);
         }
       } else {
         output += '/';
@@ -195,7 +200,7 @@ export class RouteRecognizer {
   *  `isDynanic` values for the matched route(s), or undefined if no match
   *  was found.
   */
-  recognize(path: string): RecognizedRoute[] | void {
+  recognize(path: string): RecognizeResults {
     let states = [this.rootState];
     let queryParams = {};
     let isSlashDropped = false;


### PR DESCRIPTION
This change allows the router to generate routes for all configured routes, not only those with name, which allows the router.generate method to be used reliably by the router internals.