### PR TITLE
chore: Tweak types for flow

### DIFF
--- a/src/interfaces.js
+++ b/src/interfaces.js
@@ -1,5 +1,13 @@
 import { StaticSegment, DynamicSegment, StarSegment, EpsilonSegment } from './segments';
 
+/*
+* An object that is indexed and used for route generation, particularly for dynamic routes.
+*/
+interface RouteGenerator {
+  segments: Array<StaticSegment | DynamicSegment | StarSegment | EpsilonSegment>;
+  handlers: HandlerEntry[];
+}
+
 interface RouteHandler {
   name: string;
 }
@@ -25,13 +33,4 @@ interface CharSpec {
   invalidChars?: string;
   validChars?: string;
   repeat?: boolean;
-}
-
-type Segment = StaticSegment | DynamicSegment | StarSegment | EpsilonSegment;
-/**
- * An object that is indexed and used for route generation, particularly for dynamic routes.
- */
-interface RouteGenerator {
-  segments: Segment[];
-  handlers: HandlerEntry[];
 }

--- a/src/route-recognizer.js
+++ b/src/route-recognizer.js
@@ -206,7 +206,7 @@ export class RouteRecognizer {
   *  `isDynanic` values for the matched route(s), or undefined if no match
   *  was found.
   */
-  recognize(path: string): RecognizeResults {
+  recognize(path: string): RecognizedRoute[] | void {
     let states = [this.rootState];
     let queryParams = {};
     let isSlashDropped = false;


### PR DESCRIPTION
Was using a type alias and Flow was having a hard time exporting it. I removed the alias and inlined the type for now. Additionally, Flow was duplicating comments for some reason. Moving the comment fixed the issue.

closes #38 #39